### PR TITLE
use proper key for zipkin spans

### DIFF
--- a/src/otter_conn_zipkin.erl
+++ b/src/otter_conn_zipkin.erl
@@ -24,6 +24,8 @@
 %%% -------------------------------------------------------------------
 
 -module(otter_conn_zipkin).
+-include_lib("otter_lib/include/otter.hrl").
+
 -export([
          send_buffer/0,
          store_span/1,
@@ -37,8 +39,8 @@ sup_init() ->
             [named_table, public | TableProps ]
         ) ||
         {Tab, TableProps} <- [
-            {otter_zipkin_buffer1, [{write_concurrency, true}, {keypos, 2}]},
-            {otter_zipkin_buffer2, [{write_concurrency, true}, {keypos, 2}]},
+            {otter_zipkin_buffer1, [{write_concurrency, true}, {keypos, #span.id}]},
+            {otter_zipkin_buffer2, [{write_concurrency, true}, {keypos, #span.id}]},
             {otter_zipkin_status,  [{read_concurrency, true}]}
         ]
     ],


### PR DESCRIPTION
`#span.timestamp == 2`, so if two spans share the same microsecond timestamp, one used to over the other.